### PR TITLE
Fix POSIX compliance: Remove bash-specific export -f from libraries

### DIFF
--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -441,6 +441,6 @@ list_snapshots() {
 # Export Functions
 # ============================================================================
 
-export -f generate_backup_name backup_file backup_directory
-export -f create_system_snapshot restore_file restore_system_snapshot
-export -f cleanup_old_backups list_backups list_snapshots
+#export -f generate_backup_name backup_file backup_directory
+#export -f create_system_snapshot restore_file restore_system_snapshot
+#export -f cleanup_old_backups list_backups list_snapshots

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -481,10 +481,10 @@ cleanup_on_exit() {
 # ============================================================================
 
 # Make functions available to sourcing scripts
-export -f log die require_root validate_debian check_requirements
-export -f check_disk_space verify_ssh_alive preserve_admin_access
-export -f safe_backup_file safe_modify_file file_modified
-export -f save_state get_state is_completed mark_completed
-export -f safe_service_restart safe_service_reload execute_or_simulate
-export -f show_progress show_success show_warning show_error
-export -f init_hardening_environment cleanup_on_exit
+#export -f log die require_root validate_debian check_requirements
+#export -f check_disk_space verify_ssh_alive preserve_admin_access
+#export -f safe_backup_file safe_modify_file file_modified
+#export -f save_state get_state is_completed mark_completed
+#export -f safe_service_restart safe_service_reload execute_or_simulate
+#export -f show_progress show_success show_warning show_error
+#export -f init_hardening_environment cleanup_on_exit

--- a/lib/rollback.sh
+++ b/lib/rollback.sh
@@ -470,10 +470,10 @@ cleanup_transactions() {
 # Export Functions
 # ============================================================================
 
-export -f begin_transaction commit_transaction rollback_transaction
-export -f register_rollback register_file_rollback register_command_rollback
-export -f register_service_rollback register_firewall_rollback register_sysctl_rollback
-export -f execute_rollback_action atomic_operation atomic_file_update
-export -f create_checkpoint rollback_to_checkpoint
-export -f safe_file_operation safe_service_operation
-export -f show_rollback_history cleanup_transactions
+#export -f begin_transaction commit_transaction rollback_transaction
+#export -f register_rollback register_file_rollback register_command_rollback
+#export -f register_service_rollback register_firewall_rollback register_sysctl_rollback
+#export -f execute_rollback_action atomic_operation atomic_file_update
+#export -f create_checkpoint rollback_to_checkpoint
+#export -f safe_file_operation safe_service_operation
+#export -f show_rollback_history cleanup_transactions

--- a/lib/ssh_safety.sh
+++ b/lib/ssh_safety.sh
@@ -500,7 +500,7 @@ kill_emergency_ssh() {
 # Export Functions
 # ============================================================================
 
-export -f verify_ssh_connection create_ssh_test_config test_ssh_config
-export -f update_ssh_config_safe check_ssh_setting update_ssh_setting
-export -f fix_ssh_key_permissions manage_ssh_access ensure_ssh_firewall_access
-export -f monitor_ssh_connections create_emergency_ssh_access kill_emergency_ssh
+#export -f verify_ssh_connection create_ssh_test_config test_ssh_config
+#export -f update_ssh_config_safe check_ssh_setting update_ssh_setting
+#export -f fix_ssh_key_permissions manage_ssh_access ensure_ssh_firewall_access
+#export -f monitor_ssh_connections create_emergency_ssh_access kill_emergency_ssh


### PR DESCRIPTION
## Summary

This PR fixes POSIX shell compliance issues caused by bash-specific `export -f` function export syntax in the library files. The toolkit was failing when executed with POSIX-compliant shells like dash (used as `/bin/sh` on Debian/Ubuntu systems).

## Changes

Commented out all `export -f` declarations in library files:
- `lib/common.sh` - 7 export statements
- `lib/backup.sh` - 3 export statements  
- `lib/rollback.sh` - 7 export statements
- `lib/ssh_safety.sh` - 4 export statements

The `export -f` syntax is a bash extension for exporting functions to child processes, but it is not part of the POSIX shell specification. Functions are still available to scripts that source these libraries; they just won't be automatically exported to child shells (which wasn't necessary for the toolkit's operation).

## Testing Performed

- Tested in Docker container with Ubuntu 22.04
- Verified functionality using `/bin/sh` (dash)
- Confirmed POSIX compliance with strict shell interpreter

## Impact

This fix ensures the hardening toolkit works correctly on systems where `/bin/sh` is not bash (Debian, Ubuntu, and other distributions that use dash or other POSIX shells as the default system shell).

Fixes #1